### PR TITLE
fix: handle missing analytics config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 代码块被添加背景色的问题。
 - 修复主题副标题错误取值的问题
 - 防止 Safari 中 main 元素自动获得焦点
+- 在缺少分析配置时防止错误
 
 ### Chore
 - 使用 ESLint 格式化代码。

--- a/src/components/Analytics.astro
+++ b/src/components/Analytics.astro
@@ -4,10 +4,10 @@ import UmamiAnalytics from '~/components/analytics/UmamiAnalytics.astro'
 import { themeConfig } from '~/.config'
 
 const PUBLIC_GOOGLE_ANALYTICS_ID = import.meta.env.PUBLIC_GOOGLE_ANALYTICS_ID
-const googleAnalyticsId = themeConfig.analytics.googleAnalyticsId || PUBLIC_GOOGLE_ANALYTICS_ID
+const googleAnalyticsId = themeConfig.analytics?.googleAnalyticsId || PUBLIC_GOOGLE_ANALYTICS_ID
 
 const PUBLIC_UMAMI_ANALYTICS_ID = import.meta.env.PUBLIC_UMAMI_ANALYTICS_ID
-const umamiAnalyticsId = themeConfig.analytics.umamiAnalyticsId || PUBLIC_UMAMI_ANALYTICS_ID
+const umamiAnalyticsId = themeConfig.analytics?.umamiAnalyticsId || PUBLIC_UMAMI_ANALYTICS_ID
 ---
 
 {googleAnalyticsId && <GoogleAnalytics id={googleAnalyticsId} />}

--- a/src/types/themeConfig.ts
+++ b/src/types/themeConfig.ts
@@ -20,7 +20,7 @@ export interface ThemeConfig {
   seo: ConfigSEO
   comment: Partial<ConfigComment>
   rss: ConfigRSS
-  analytics: ConfigAnalytics
+  analytics: Partial<ConfigAnalytics>
   latex: ConfigLaTeX
 }
 


### PR DESCRIPTION
## Summary
- avoid errors when analytics config is undefined
- document analytics config fix in changelog

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a6b49bf85483319bbe33e5f579e192