### PR TITLE
chore: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
     directory: / # Location of package manifests
     schedule:
       interval: weekly
-    ignore:
-      - dependency-name: '*'
-        update-types: ['version-update:semver-patch']
+    groups:
+      major:
+        update-types:
+          - major
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- group major updates separately from minor+patch
- run dependabot weekly

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b7093df49c8331b3686ea2a9b47d6f