### PR TITLE
fix: unify homepage text color

### DIFF
--- a/uno.config.js
+++ b/uno.config.js
@@ -14,7 +14,9 @@ const { colorsDark, colorsLight, fonts } = themeConfig.appearance
 
 const cssExtend = {
   ':root': {
-    '--prose-borders': '#eee',
+    '--un-prose-borders': '#eee',
+    '--un-prose-body': 'var(--uno-colors-primary)',
+    '--un-prose-invert-body': 'var(--uno-colors-primary)',
   },
 
   'code::before,code::after': {


### PR DESCRIPTION
## Summary
- ensure typography plugin uses global text color in light and dark modes

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b7f09f455c8331afddf111a099ff64