### PR TITLE
fix: unify homepage text color

### DIFF
--- a/uno.config.js
+++ b/uno.config.js
@@ -15,6 +15,8 @@ const { colorsDark, colorsLight, fonts } = themeConfig.appearance
 const cssExtend = {
   ':root': {
     '--prose-borders': '#eee',
+    '--un-prose-body': 'inherit',
+    '--un-prose-invert-body': 'inherit',
   },
 
   'code::before,code::after': {


### PR DESCRIPTION
## Summary
- let typography body text inherit theme color to match archives and categories

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b7f09f455c8331afddf111a099ff64