### PR TITLE
Refine theme rendering system

### DIFF
--- a/src/components/ThemeScript.astro
+++ b/src/components/ThemeScript.astro
@@ -1,33 +1,20 @@
 ---
-import { themeConfig } from "~/.config";
+import { themeConfig } from '~/.config'
 
-const theme = themeConfig.appearance.theme;
+const theme = themeConfig.appearance.theme
 ---
 
 <script is:inline define:vars={{ theme }}>
-  function updateTheme(theme) {
-    // Check if theme is system
-    if (theme === "system") {
-      // Check OS preference
-      const prefersDark = window.matchMedia(
-        "(prefers-color-scheme: dark)"
-      ).matches;
-      document.documentElement.classList.toggle("dark", prefersDark);
-    } else {
-      // Set theme directly
-      document.documentElement.classList.toggle("dark", theme === "dark");
-    }
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+
+  function setTheme() {
+    const isDark = theme === 'dark' || (theme === 'system' && mediaQuery.matches)
+    document.documentElement.classList.toggle('dark', isDark)
+    document.documentElement.dataset.theme = isDark ? 'dark' : 'light'
   }
 
-  // Initial theme setup
-  updateTheme(theme);
+  setTheme()
 
-  // Listen for OS theme changes
-  window
-    .matchMedia("(prefers-color-scheme: dark)")
-    .addEventListener("change", (e) => {
-      if (theme === "system") {
-        document.documentElement.classList.toggle("dark", e.matches);
-      }
-    });
+  if (theme === 'system')
+    mediaQuery.addEventListener('change', setTheme)
 </script>

--- a/src/layouts/LayoutDefault.astro
+++ b/src/layouts/LayoutDefault.astro
@@ -10,7 +10,8 @@ import ThemeScript from '~/components/ThemeScript.astro'
 import '~/styles/global.css'
 
 const lang = themeConfig.appearance.locale ?? 'en-us'
-const dark = themeConfig.appearance.theme === 'dark'
+const initialTheme = themeConfig.appearance.theme
+const dark = initialTheme === 'dark'
 ---
 
 <html lang={lang} class:list={['animation-prepared', { dark }]}>

--- a/src/layouts/LayoutPost.astro
+++ b/src/layouts/LayoutPost.astro
@@ -10,7 +10,7 @@ const { post } = Astro.props
 ---
 
 <article
-  class="prose max-w-none prose-headings:font-header prose-headings:font-bold prose-headings:c-primary prose-a:c-primary"
+  class="post-prose prose-headings:font-header prose-headings:font-bold prose-headings:c-primary prose-a:c-primary"
 >
   <PostMeta post={post} headingTag="h1" linkTitle={false} />
   <slot />

--- a/src/layouts/LayoutPostList.astro
+++ b/src/layouts/LayoutPostList.astro
@@ -10,7 +10,7 @@ const { post } = Astro.props
 ---
 
 <article
-  class="prose max-w-none prose-headings:font-header prose-headings:font-bold prose-headings:c-primary prose-a:c-primary"
+  class="post-prose prose-headings:font-header prose-headings:font-bold prose-headings:c-primary prose-a:c-primary"
 >
   <PostMeta post={post} headingTag="h2" linkTitle={true} />
   <div class="post-list-preview">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,42 +1,35 @@
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;700&family=Noto+Serif+SC:wght@400;700&display=swap');
 
 :root {
-  --uno-colors-primary: theme('colors.primary');
-  --uno-colors-background: theme('colors.background');
-  --uno-fonts-ui: theme('fontFamily.ui');
-  --uno-fonts-header: theme('fontFamily.header');
-  --uno-colors-shadow: theme('colors.shadow');
+  color-scheme: light;
 }
 
+:root.dark {
+  color-scheme: dark;
+}
 
 .font-header {
-  font-family: var(--uno-fonts-header);
+  font-family: theme('fontFamily.header');
 }
+
 html {
-  --at-apply: antialiased;
-  --at-apply: 'bg-background c-primary font-ui text-shadow-color-shadow';
+  --at-apply: 'antialiased bg-background c-primary font-ui text-shadow-color-shadow';
 
-  text-shadow: 1px 1px 1px var(--uno-colors-shadow);
+  text-shadow: 1px 1px 1px var(--color-shadow);
   background-size: 7px 7px;
-  background-image: linear-gradient(to right, var(--uno-colors-shadow) 1px, transparent 1px),
-    linear-gradient(to bottom, var(--uno-colors-shadow) 1px, transparent 1px);
+  background-image: linear-gradient(to right, var(--color-shadow) 1px, transparent 1px),
+    linear-gradient(to bottom, var(--color-shadow) 1px, transparent 1px);
 }
 
-.dark .prose {
-  color: #e5e7eb;
-}
-
-.dark .prose :where(h1, h2, h3, h4, h5, h6) {
-  color: #f9fafb;
-}
-
-.dark .prose :where(strong, b) {
-  color: #f9fafb;
+.prose {
+  --un-prose-body: var(--color-primary);
+  --un-prose-headings: var(--color-primary);
+  --un-prose-links: var(--color-primary);
+  --un-prose-bold: var(--color-primary);
+  --un-prose-borders: color-mix(in srgb, var(--color-primary) 18%, transparent);
 }
 
 :where(a):not(.not-underline-hover) {
-  --at-apply: 'p-1.5px';
-  --at-apply: 'decoration-underline decoration-0.1em decoration-offset-2px';
-  --at-apply: 'ease-in-out duration-300ms';
+  --at-apply: 'p-1.5px decoration-underline decoration-0.1em decoration-offset-2px ease-in-out duration-300ms';
   --at-apply: 'hover:(c-background bg-primary decoration-primary)';
 }

--- a/uno.config.js
+++ b/uno.config.js
@@ -7,37 +7,50 @@ import {
   presetWind4,
   transformerVariantGroup,
 } from 'unocss'
-import presetTheme from 'unocss-preset-theme'
 import { themeConfig } from './src/.config'
 
 const { colorsDark, colorsLight, fonts } = themeConfig.appearance
 
-const cssExtend = {
-  ':root': {
-    '--prose-borders': '#eee',
-  },
+function makeThemeVars(colors, shadow) {
+  return {
+    '--color-primary': colors.primary,
+    '--color-background': colors.background,
+    '--color-shadow': shadow,
+  }
+}
 
+const cssExtend = {
   'code::before,code::after': {
     content: 'none',
   },
 
   ':where(:not(pre):not(a) > code)': {
     'white-space': 'normal',
-    'word-wrap': 'break-word',
-    'padding': '2px 4px',
+    'overflow-wrap': 'anywhere',
+    'padding': '0.125rem 0.25rem',
     'color': '#c7254e',
-    'font-size': '90%',
+    'font-size': '0.9em',
     'background-color': '#f9f2f4',
-    'border-radius': '4px',
+    'border-radius': '0.25rem',
+  },
+
+  '.dark :where(:not(pre):not(a) > code)': {
+    'color': '#fda4af',
+    'background-color': 'rgb(255 255 255 / 0.08)',
   },
 
   'li': {
     'white-space': 'normal',
-    'word-wrap': 'break-word',
+    'overflow-wrap': 'anywhere',
   },
 }
 
 export default defineConfig({
+  preflights: [
+    {
+      getCSS: () => `:root{${Object.entries(makeThemeVars(colorsLight, '#0000000A')).map(([key, value]) => `${key}:${value}`).join(';')}}.dark{${Object.entries(makeThemeVars(colorsDark, '#FFFFFF0A')).map(([key, value]) => `${key}:${value}`).join(';')}}`,
+    },
+  ],
   rules: [
     [
       /^row-(\d+)-(\d)$/,
@@ -49,7 +62,7 @@ export default defineConfig({
     ],
     [
       /^scrollbar-hide$/,
-      ([_]) => `.scrollbar-hide { scrollbar-width:none;-ms-overflow-style: none; }
+      () => `.scrollbar-hide { scrollbar-width:none;-ms-overflow-style: none; }
       .scrollbar-hide::-webkit-scrollbar {display:none;}`,
     ],
   ],
@@ -58,21 +71,18 @@ export default defineConfig({
     presetTypography({ cssExtend }),
     presetAttributify(),
     presetIcons({ scale: 1.2, warn: true }),
-    presetTheme ({
-      theme: {
-        dark: {
-          colors: { ...colorsDark, shadow: '#FFFFFF0A' },
-          // TODO 需要配置代码块颜色
-        },
-      },
-    }),
   ],
   theme: {
-    colors: { ...colorsLight, shadow: '#0000000A' },
+    colors: {
+      primary: 'var(--color-primary)',
+      background: 'var(--color-background)',
+      shadow: 'var(--color-shadow)',
+    },
     fontFamily: fonts,
   },
   shortcuts: [
     ['post-title', 'text-5 font-bold lh-7.5 m-0'],
+    ['post-prose', 'prose max-w-none'],
   ],
   transformers: [transformerDirectives(), transformerVariantGroup()],
   safelist: [


### PR DESCRIPTION
### Motivation
- Modernize and simplify the theme/rendering pipeline by removing duplicated/unnecessary variable mappings and making color variables driven directly from the existing `themeConfig` appearance settings.
- Make client-side theme handling cleaner and more reliable across `light`/`dark`/`system` modes while keeping server-side behavior for explicit dark configuration.

### Description
- Replace the earlier theme duplication with UnoCSS `preflights` that emit CSS variables (`--color-primary`, `--color-background`, `--color-shadow`) from `themeConfig.appearance` and map Uno `theme.colors` to those variables in `uno.config.js`.
- Simplify `src/styles/global.css` to use the shared CSS variables and unify prose colors via `--un-prose-*` variables, remove redundant Uno variable mirrors, and keep color-scheme metadata for light/dark.
- Modernize `src/components/ThemeScript.astro` to compute `isDark` once, set both the `dark` class and `data-theme`, and only register the `prefers-color-scheme` listener when `theme === 'system'`.
- Add a shared UnoCSS shortcut `post-prose` and update `src/layouts/LayoutPost.astro` and `src/layouts/LayoutPostList.astro` to use it, while keeping the prose heading and link modifiers alongside the shortcut.
- Improve code-block/prose wrapping rules in `cssExtend` and small padding/font-size tweaks for inline code for better multi-platform rendering.

### Testing
- Ran a production build with `PATH=/root/.nvm/versions/node/v22.22.2/bin:$PATH pnpm build` which completed successfully and produced a static site (108 pages built). 
- Started a preview with `pnpm preview` and exercised the site locally during the build/preview run successfully. 
- Ran `pnpm lint`; linting failed due to pre-existing repository lint issues in unrelated files and content (the new UnoCSS/JS changes were adjusted to address a local lint finding before commit).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e981fb71483319733ddd797b566e4)