### PR TITLE
Fix Astro rehype-katex plugin type mismatch

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,3 +1,4 @@
+import type { RehypePlugins } from 'astro'
 import mdx from '@astrojs/mdx'
 import sitemap from '@astrojs/sitemap'
 import swup from '@swup/astro'
@@ -18,7 +19,7 @@ export default defineConfig({
       remarkMath,
     ],
     rehypePlugins: [
-      rehypeKatex,
+      rehypeKatex as RehypePlugins[number],
     ],
     shikiConfig: {
       theme: 'dracula',


### PR DESCRIPTION
### Motivation
- Resolve a TypeScript build failure caused by duplicate `@types/hast` instances after dependency updates by aligning the `rehype-katex` plugin with Astro's public markdown plugin type so `astro check`/build can complete.

### Description
- Import `RehypePlugins` from `astro` and cast the `rehype-katex` entry to `rehypeKatex as RehypePlugins[number]` in `astro.config.ts` to satisfy the expected rehype plugin type without changing runtime behavior.

### Testing
- Automated runs: `npm run build` under Node `v22.22.2` completed successfully; `pnpm exec eslint astro.config.ts` passed; `pnpm exec tsc --noEmit` verified the original `rehype-katex` type error is resolved while unrelated `astro-seo` type export issues remain; `npm run build` under Node `v20.20.2` failed due to Astro 7 requiring `>=22.12.0` (environment expected failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61a32d554083319ed089685bb0aa36)