### PR TITLE
fix: silence Astro build warnings

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,4 +1,5 @@
-import type { RehypePlugins } from 'astro'
+import type { RehypePlugins } from '@astrojs/markdown-remark'
+import { unified } from '@astrojs/markdown-remark'
 import mdx from '@astrojs/mdx'
 import sitemap from '@astrojs/sitemap'
 import swup from '@swup/astro'
@@ -15,12 +16,14 @@ export default defineConfig({
   prefetch: true,
   base: '/',
   markdown: {
-    remarkPlugins: [
-      remarkMath,
-    ],
-    rehypePlugins: [
-      rehypeKatex as RehypePlugins[number],
-    ],
+    processor: unified({
+      remarkPlugins: [
+        remarkMath,
+      ],
+      rehypePlugins: [
+        rehypeKatex as RehypePlugins[number],
+      ],
+    }),
     shikiConfig: {
       theme: 'dracula',
       wrap: true,

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.9.10",
+    "@astrojs/markdown-remark": "^7.2.2",
     "@astrojs/mdx": "^7.0.5",
     "@astrojs/rss": "^4.0.19",
     "@astrojs/sitemap": "^3.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.10
         version: 0.9.10(prettier-plugin-astro@0.14.1)(prettier@3.9.6)(typescript@6.0.3)
+      '@astrojs/markdown-remark':
+        specifier: ^7.2.2
+        version: 7.2.2
       '@astrojs/mdx':
         specifier: ^7.0.5
         version: 7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.1.6(@astrojs/markdown-remark@7.2.2)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.2)(jiti@2.7.0)(rollup@2.80.0)(terser@5.46.0)(tsx@4.20.3)(yaml@2.8.3))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
 ignoredBuiltDependencies:
   - simple-git-hooks
+onlyBuiltDependencies:
+  - esbuild
+  - swup

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,6 @@
 import { glob } from 'astro/loaders'
-import { defineCollection, z } from 'astro:content'
+import { defineCollection } from 'astro:content'
+import { z } from 'astro/zod'
 
 const posts = defineCollection({
   loader: glob({ pattern: '**/*.{md,mdx}', base: './src/content/posts' }),

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,2 @@
+# Cloudflare Pages configuration
+pages_build_output_dir = "./dist"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,2 +1,3 @@
+name = "blog"
 # Cloudflare Pages configuration
 pages_build_output_dir = "./dist"


### PR DESCRIPTION
### Motivation
- Remove deprecation and build warnings emitted during Astro builds by moving deprecated Markdown plugin config to the Astro 7 `unified` processor and stop using the deprecated `z` re-export from `astro:content`.
- Ensure the Markdown processor dependency is explicit so the `unified` import is available at build time.
- Silence the pnpm ignored-build-scripts warning by approving the build scripts required for certain dependencies.

### Description
- Replace `markdown.remarkPlugins`/`markdown.rehypePlugins` with `markdown.processor: unified({...})` in `astro.config.ts` and import `unified`/`RehypePlugins` from `@astrojs/markdown-remark`.
- Change the content schema import in `src/content.config.ts` to `import { z } from 'astro/zod'` and keep `defineCollection` from `astro:content` to avoid the deprecated re-export.
- Add `@astrojs/markdown-remark` to `dependencies` in `package.json` and reflect the change in `pnpm-lock.yaml` so the processor is an explicit dependency.
- Update `pnpm-workspace.yaml` to list `esbuild` and `swup` in `onlyBuiltDependencies` while keeping `simple-git-hooks` in `ignoredBuiltDependencies` to address pnpm build-script prompts.

### Testing
- Ran `source ~/.nvm/nvm.sh && nvm use 22.22.2 && pnpm build`, and the build completed successfully (Astro check + Astro build passed and produced the static `dist` output).
- Ran `pnpm lint`, which failed due to an existing ESLint / `eslint-plugin-unicorn` compatibility error (`TypeError: mapTypes.union is not a function`), unrelated to the Markdown/astro config changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d59be27b88331b253ff156a4bdee9)